### PR TITLE
Implement I/O safety traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ async-lock = "2.3.0"
 blocking = "1.0.0"
 futures-lite = "1.2.0"
 
+[build-dependencies]
+autocfg = "1"
+
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.78"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    let cfg = match autocfg::AutoCfg::new() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            println!(
+                "cargo:warning=async-fs: failed to detect compiler features: {}",
+                e
+            );
+            return;
+        }
+    };
+
+    if !cfg.probe_rustc_version(1, 63) {
+        autocfg::emit("async_fs_no_io_safety");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1091,6 +1091,34 @@ impl std::os::windows::io::AsRawHandle for File {
     }
 }
 
+#[cfg(all(not(async_fs_no_io_safety), unix))]
+impl From<std::os::unix::io::OwnedFd> for File {
+    fn from(fd: std::os::unix::io::OwnedFd) -> Self {
+        File::from(std::fs::File::from(fd))
+    }
+}
+
+#[cfg(all(not(async_fs_no_io_safety), windows))]
+impl From<std::os::windows::io::OwnedHandle> for File {
+    fn from(fd: std::os::windows::io::OwnedHandle) -> Self {
+        File::from(std::fs::File::from(fd))
+    }
+}
+
+#[cfg(all(not(async_fs_no_io_safety), unix))]
+impl std::os::unix::io::AsFd for File {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
+        self.file.as_fd()
+    }
+}
+
+#[cfg(all(not(async_fs_no_io_safety), windows))]
+impl std::os::windows::io::AsHandle for File {
+    fn as_handle(&self) -> std::os::windows::io::BorrowedHandle<'_> {
+        self.file.as_handle()
+    }
+}
+
 impl AsyncRead for File {
     fn poll_read(
         mut self: Pin<&mut Self>,


### PR DESCRIPTION
This PR adds I/O safety traits introduced in Rust 1.63 using the `autocfg` system. I added `AsFd/Handle` and `From<OwnedFd/Handle>` traits mirroring the existing `AsRawFd/Handle` and `FromRawFd/Handle` traits.

See also: sunfishcode/io-lifetimes#38