### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Version 2.0.0
+
+- **Breaking:** Seal extension traits. (#20)
+- **Breaking:** Remove unsafe implementations of the `FromRawFd`/`FromRawHandle` traits. (#26)
+- Avoid using a `build.rs` script for feature autodetection. (#17)
+- Remove the `autocfg` dependency. (#18)
+- Avoid a heap allocation in the `ReadDir` implementation. (#23)
+
 # Version 1.6.0
 
 - Implement I/O safety traits on Rust 1.63+ (#13)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "async-fs"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v1.x.y" git tag
-version = "1.6.0"
+# - Create "v2.x.y" git tag
+version = "2.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.63"


### PR DESCRIPTION
- **Breaking:** Seal extension traits. (#20)
- **Breaking:** Remove unsafe implementations of the `FromRawFd`/`FromRawHandle` traits. (#26)
- Avoid using a `build.rs` script for feature autodetection. (#17)
- Remove the `autocfg` dependency. (#18)
- Avoid a heap allocation in the `ReadDir` implementation. (#23)