### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 2.1.0
+
+- Bump `async-lock` and `futures-lite` to their latest versions. (#27, #28)
+
 # Version 2.0.0
 
 - **Breaking:** Seal extension traits. (#20)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-fs"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.0.0"
+version = "2.1.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.63"


### PR DESCRIPTION
- Bump `async-lock` and `futures-lite` to their latest versions. (#27, #28)
