### PR TITLE
Fix documentation of `DirEntry::metadata`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,10 +388,9 @@ impl DirEntry {
 
     /// Reads the metadata for this entry.
     ///
-    /// This function will traverse symbolic links to read the metadata.
+    /// This function will not traverse symbolic links if this entry points at one.
     ///
-    /// If you want to read metadata without following symbolic links, use [`symlink_metadata()`]
-    /// instead.
+    /// If you want to read metadata with following symbolic links, use [`metadata()`] instead.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
std [`DirEntry::metadata`](https://doc.rust-lang.org/std/fs/struct.DirEntry.html#method.metadata) doesn't follow symlinks, and smol `DirEntry::metadata` uses std version internally, so it also doesn't follow symlinks. Adjust docs to reflect that.